### PR TITLE
Remove v. 1.0 constraint from composer require in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -112,7 +112,7 @@ public function boot()
 This package is installed via [Composer](https://getcomposer.org/). To install, run the following command.
 
 ```bash
-composer require "dyrynda/laravel-model-uuid:~1.0"
+composer require "dyrynda/laravel-model-uuid"
 ```
 ## Support
 

--- a/README.md
+++ b/README.md
@@ -112,7 +112,7 @@ public function boot()
 This package is installed via [Composer](https://getcomposer.org/). To install, run the following command.
 
 ```bash
-composer require "dyrynda/laravel-model-uuid"
+composer require "dyrynda/laravel-model-uuid:~2.0"
 ```
 ## Support
 


### PR DESCRIPTION
In the README, under "Installation", it says to ```composer require "dyrynda/laravel-model-uuid:~1.0"```, however, pulling in version 1.0 on the latest Laravel version, will cause failures out-of-the-box.

I assume it would be better to use ```composer require dyrynda/laravel-model-uuid```, which will set the constraint to ^2.0.0.

## Before
composer require "dyrynda/laravel-model-uuid:~1.0"

which will pull in version 1.0.1

## After
composer require dyrynda/laravel-model-uuid

which will set the constraint to ^2.0.0 and pull in the current version