### PR TITLE
Compatibility for 5.5

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -17,8 +17,8 @@
     ],
     "require": {
         "php": ">=5.6.4",
-        "illuminate/database": "5.3.* || 5.4.*",
-        "illuminate/events": "5.3.* || 5.4.*",
+        "illuminate/database": "5.3.* || 5.4.* || 5.5.*",
+        "illuminate/events": "5.3.* || 5.4.* || 5.5.*",
         "ramsey/uuid": "3.6.*"
     },
     "autoload": {

--- a/composer.json
+++ b/composer.json
@@ -36,6 +36,5 @@
     },
     "suggest": {
         "dyrynda/laravel-efficient-uuid": "Override Laravel's default query grammar to efficiently store UUIDs. (~1.0)"
-    },
-    "minimum-stability": "stable"
+    }
 }


### PR DESCRIPTION
Hello,

This is just updating illuminate dependencies for 5.5. I've been using my fork for a little while now, everything just works fine.

**Important**: I had to remove the minimum stability flag to use with 5.5 at the moment, because it's still on dev. I guess you might want to wait until release to merge this and keep the stable flag?