### PR TITLE
fix the dependency with illuminate/events 5.6.*

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -18,7 +18,7 @@
     "require": {
         "php": ">=5.6.4 || >= 7.0",
         "illuminate/database": "5.3.* || 5.4.* || 5.5.* || 5.6.*",
-        "illuminate/events": "5.3.* || 5.4.* || 5.5.* || 5.6",
+        "illuminate/events": "5.3.* || 5.4.* || 5.5.* || 5.6.*",
         "ramsey/uuid": "~3.6"
     },
     "autoload": {


### PR DESCRIPTION
At the moment it is impossible to do a composer update with this package.  We are stuck with Laravel 5.6.0.