### PR TITLE
Add support for time-ordered UUIDs introduced in Laravel 5.6

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -6,28 +6,8 @@ cache:
 
 matrix:
   include:
-    - php: 5.6.4
-      env: ILLUMINATE_VERSION=5.3.*
-    - php: 5.6.4
-      env: ILLUMINATE_VERSION=5.4.*
-    - php: 7.0
-      env: ILLUMINATE_VERSION=5.3.*
-    - php: 7.0
-      env: ILLUMINATE_VERSION=5.4.*
-    - php: 7.0
-      env: ILLUMINATE_VERSION=5.5.*
-    - php: 7.1
-      env: ILLUMINATE_VERSION=5.3.*
-    - php: 7.1
-      env: ILLUMINATE_VERSION=5.4.*
-    - php: 7.1
-      env: ILLUMINATE_VERSION=5.5.*
     - php: 7.1
       env: ILLUMINATE_VERSION=5.6.*
-    - php: 7.2
-      env: ILLUMINATE_VERSION=5.4.*
-    - php: 7.2
-      env: ILLUMINATE_VERSION=5.5.*
     - php: 7.2
       env: ILLUMINATE_VERSION=5.6.*
 

--- a/README.md
+++ b/README.md
@@ -1,5 +1,5 @@
 # Laravel Model UUIDs
-## v3.1.0
+## v4.0.0
 
 [![Build Status](https://travis-ci.org/michaeldyrynda/laravel-model-uuid.svg?branch=master)](https://travis-ci.org/michaeldyrynda/laravel-model-uuid)
 [![Scrutinizer Code Quality](https://scrutinizer-ci.com/g/michaeldyrynda/laravel-model-uuid/badges/quality-score.png?b=master)](https://scrutinizer-ci.com/g/michaeldyrynda/laravel-model-uuid/?branch=master)
@@ -19,9 +19,7 @@ For more information, check out [this post](https://www.percona.com/blog/2014/12
 
 Take a look at [laravel-efficient-uuid](https://github.com/michaeldyrynda/laravel-efficient-uuid) if you want to make it easy to generate migrations that efficiently store UUID in your database.
 
-This package supports Laravel 5.5 as of version 3.0.0.
-
-This package supports Laravel 5.6 as of version 3.1.0.
+This package supports time-ordered UUIDs in Laravel 5.6 as of version 4.0.0.
 
 ## Code Samples
 
@@ -43,7 +41,7 @@ class Post extends Model
 
 It is assumed that you already have a field named `uuid` in your database, which is used to store the generated value.
 
-By default, this package will use UUID version 4 values, however, you are welcome to use `uuid1`, `uuid3`, `uuid4`, or `uuid5` by specifying the protected property `$uuidVersion` in your model.
+By default, this package will use UUID version 4 values, however, you are welcome to use `uuid1`, `uuid3`, `uuid4`, or `uuid5` by specifying the protected property `$uuidVersion` in your model. Should you wish to take advantage of ordered UUID (version 4) values that were introduced in Laravel 5.6, you should specify `ordered` as the `$uuidVersion` in your model.
 
 ```php
 <?php
@@ -116,7 +114,7 @@ public function boot()
 This package is installed via [Composer](https://getcomposer.org/). To install, run the following command.
 
 ```bash
-composer require "dyrynda/laravel-model-uuid:~3.0"
+composer require "dyrynda/laravel-model-uuid:~4.0"
 ```
 ## Support
 

--- a/composer.json
+++ b/composer.json
@@ -16,10 +16,12 @@
         }
     ],
     "require": {
-        "php": ">=5.6.4 || >= 7.0",
-        "illuminate/database": "5.3.* || 5.4.* || 5.5.* || 5.6.*",
-        "illuminate/events": "5.3.* || 5.4.* || 5.5.* || 5.6.*",
-        "ramsey/uuid": "~3.6"
+        "php": ">= 7.1.3",
+        "illuminate/database": "5.6.*",
+        "illuminate/events": "5.6.*",
+        "illuminate/support": "5.6.*",
+        "ramsey/uuid": "~3.7",
+        "moontoast/math": "^1.1"
     },
     "autoload": {
         "psr-4": {
@@ -27,7 +29,7 @@
         }
     },
     "require-dev": {
-        "phpunit/phpunit": "~5.7"
+        "phpunit/phpunit": "~7.0"
     },
     "autoload-dev": {
         "psr-4": {

--- a/src/GeneratesUuid.php
+++ b/src/GeneratesUuid.php
@@ -3,6 +3,7 @@
 namespace Dyrynda\Database\Support;
 
 use Ramsey\Uuid\Uuid;
+use Illuminate\Support\Str;
 
 /**
  * UUID generation trait.
@@ -29,6 +30,7 @@ trait GeneratesUuid
         'uuid3',
         'uuid4',
         'uuid5',
+        'ordered',
     ];
 
     /**
@@ -70,7 +72,11 @@ trait GeneratesUuid
      */
     public function resolveUuid()
     {
-        return call_user_func([Uuid::class, $this->resolveUuidVersion()]);
+        if (($version = $this->resolveUuidVersion()) == 'ordered') {
+            return Str::orderedUuid();
+        }
+
+        return call_user_func([Uuid::class, $version]);
     }
 
     /**

--- a/tests/Feature/UuidTest.php
+++ b/tests/Feature/UuidTest.php
@@ -4,12 +4,13 @@ namespace Tests\Feature;
 
 use Tests\Fixtures\Post;
 use Tests\Fixtures\UncastPost;
-use PHPUnit_Framework_TestCase;
+use Tests\Fixtures\OrderedPost;
+use PHPUnit\Framework\TestCase;
 use Illuminate\Events\Dispatcher;
 use Illuminate\Container\Container;
 use Illuminate\Database\Capsule\Manager;
 
-class UuidTest extends PHPUnit_Framework_TestCase
+class UuidTest extends TestCase
 {
     public static function setupBeforeClass()
     {
@@ -31,7 +32,7 @@ class UuidTest extends PHPUnit_Framework_TestCase
     {
         $post = Post::create(['title' => 'Test post']);
 
-        $this->assertNotNull($post);
+        $this->assertNotNull($post->uuid);
     }
 
     /** @test */
@@ -86,5 +87,14 @@ class UuidTest extends PHPUnit_Framework_TestCase
 
         $this->assertInstanceOf(UncastPost::class, $post);
         $this->assertSame($uuid, $post->uuid);
+    }
+
+    /** @test */
+    public function it_handles_time_ordered_uuids()
+    {
+        $post = OrderedPost::create(['title' => 'test-post']);
+
+        $this->assertInstanceOf(OrderedPost::class, $post);
+        $this->assertNotNull($post->uuid);
     }
 }

--- a/tests/Fixtures/OrderedPost.php
+++ b/tests/Fixtures/OrderedPost.php
@@ -1,0 +1,8 @@
+<?php
+
+namespace Tests\Fixtures;
+
+class OrderedPost extends Model
+{
+    protected $uuidVersion = 'ordered';
+}

--- a/tests/Unit/UuidResolversTest.php
+++ b/tests/Unit/UuidResolversTest.php
@@ -19,6 +19,7 @@ class UuidResolversTest extends TestCase
             ['uuid4', 'uuid4'],
             ['uuid5', 'uuid5'],
             ['uuid999', 'uuid4'],
+            ['ordered', 'ordered'],
         ];
     }
 


### PR DESCRIPTION
In doing so, we pin the minimum version of this package to 5.6 components, lifting minimum PHP version to 7.1.3.