### PR TITLE
Make UUID column configurable

### DIFF
--- a/.styleci.yml
+++ b/.styleci.yml
@@ -1,3 +1,1 @@
 preset: laravel
-
-linting: true

--- a/README.md
+++ b/README.md
@@ -1,5 +1,5 @@
 # Laravel Model UUIDs
-## v4.0.0
+## v4.0.1
 
 [![Build Status](https://travis-ci.org/michaeldyrynda/laravel-model-uuid.svg?branch=master)](https://travis-ci.org/michaeldyrynda/laravel-model-uuid)
 [![Scrutinizer Code Quality](https://scrutinizer-ci.com/g/michaeldyrynda/laravel-model-uuid/badges/quality-score.png?b=master)](https://scrutinizer-ci.com/g/michaeldyrynda/laravel-model-uuid/?branch=master)
@@ -39,7 +39,17 @@ class Post extends Model
 }
 ```
 
-It is assumed that you already have a field named `uuid` in your database, which is used to store the generated value.
+It is assumed that you already have a field named `uuid` in your database, which is used to store the generated value. If you wish to use a custom column name, for example if you want your primary `id` column to be a `UUID`, you can define a `uuidColumn` method in your model.
+
+```php
+class Post extends Model
+{
+    public function uuidColumn()
+    {
+        return 'custom_column';
+    }
+}
+```
 
 By default, this package will use UUID version 4 values, however, you are welcome to use `uuid1`, `uuid3`, `uuid4`, or `uuid5` by specifying the protected property `$uuidVersion` in your model. Should you wish to take advantage of ordered UUID (version 4) values that were introduced in Laravel 5.6, you should specify `ordered` as the `$uuidVersion` in your model.
 

--- a/phpunit.xml
+++ b/phpunit.xml
@@ -6,8 +6,7 @@
          convertNoticesToExceptions="true"
          convertWarningsToExceptions="true"
          processIsolation="false"
-         stopOnFailure="false"
-         syntaxCheck="false">
+         stopOnFailure="false">
     <testsuites>
         <testsuite name="Application Test Suite">
             <directory>./tests/</directory>

--- a/src/GeneratesUuid.php
+++ b/src/GeneratesUuid.php
@@ -56,13 +56,23 @@ trait GeneratesUuid
             /* @var \Illuminate\Database\Eloquent\Model|static $model */
             $uuid = $model->resolveUuid();
 
-            if (isset($model->attributes['uuid']) && ! is_null($model->attributes['uuid'])) {
+            if (isset($model->attributes[$model->uuidColumn()]) && ! is_null($model->attributes[$model->uuidColumn()])) {
                 /* @var \Ramsey\Uuid\Uuid $uuid */
-                $uuid = $uuid->fromString(strtolower($model->attributes['uuid']));
+                $uuid = $uuid->fromString(strtolower($model->attributes[$model->uuidColumn()]));
             }
 
-            $model->attributes['uuid'] = $model->hasCast('uuid') ? $uuid->getBytes() : $uuid->toString();
+            $model->attributes[$model->uuidColumn()] = $model->hasCast('uuid') ? $uuid->getBytes() : $uuid->toString();
         });
+    }
+
+    /**
+     * The name of the column that should be used for the UUID.
+     * 
+     * @return string
+     */
+    public function uuidColumn()
+    {
+        return 'uuid';
     }
 
     /**
@@ -103,11 +113,11 @@ trait GeneratesUuid
      */
     public function scopeWhereUuid($query, $uuid)
     {
-        if ($this->hasCast('uuid')) {
+        if ($this->hasCast($this->uuidColumn())) {
             $uuid = $this->resolveUuid()->fromString($uuid)->getBytes();
         }
 
-        return $query->where('uuid', $uuid);
+        return $query->where($this->uuidColumn(), $uuid);
     }
 
     /**
@@ -119,7 +129,7 @@ trait GeneratesUuid
      */
     protected function castAttribute($key, $value)
     {
-        if ($key === 'uuid' && ! is_null($value)) {
+        if ($key === $this->uuidColumn() && ! is_null($value)) {
             return $this->resolveUuid()->fromBytes($value)->toString();
         }
 

--- a/tests/Feature/UuidTest.php
+++ b/tests/Feature/UuidTest.php
@@ -7,6 +7,7 @@ use Tests\Fixtures\UncastPost;
 use PHPUnit\Framework\TestCase;
 use Tests\Fixtures\OrderedPost;
 use Illuminate\Events\Dispatcher;
+use Tests\Fixtures\CustomUuidPost;
 use Illuminate\Container\Container;
 use Illuminate\Database\Capsule\Manager;
 
@@ -23,6 +24,7 @@ class UuidTest extends TestCase
         $manager->schema()->create('posts', function ($table) {
             $table->increments('id');
             $table->uuid('uuid')->nullable()->default(null);
+            $table->uuid('custom_uuid')->nullable()->default(null);
             $table->string('title');
         });
     }

--- a/tests/Feature/UuidTest.php
+++ b/tests/Feature/UuidTest.php
@@ -97,4 +97,12 @@ class UuidTest extends TestCase
         $this->assertInstanceOf(OrderedPost::class, $post);
         $this->assertNotNull($post->uuid);
     }
+
+    /** @test */
+    public function it_allows_configurable_uuid_column_names()
+    {
+        $post = CustomUuidPost::create(['title' => 'test-post']);
+
+        $this->assertNotNull($post->custom_uuid);
+    }
 }

--- a/tests/Fixtures/CustomUuidPost.php
+++ b/tests/Fixtures/CustomUuidPost.php
@@ -1,0 +1,11 @@
+<?php
+
+namespace Tests\Fixtures;
+
+class CustomUuidPost extends Model
+{
+    public function uuidColumn()
+    {
+        return 'custom_uuid';
+    }
+}


### PR DESCRIPTION
Move the hardcoded `uuid` value to a public `uuidColumn` method. This allows models to override the default column name, facilitating those who want to just use a UUID for the model identifier.

Fixes #43 