### PR TITLE
Fixed bug when using custom UUID column and casting

### DIFF
--- a/src/GeneratesUuid.php
+++ b/src/GeneratesUuid.php
@@ -61,7 +61,7 @@ trait GeneratesUuid
                 $uuid = $uuid->fromString(strtolower($model->attributes[$model->uuidColumn()]));
             }
 
-            $model->attributes[$model->uuidColumn()] = $model->hasCast('uuid') ? $uuid->getBytes() : $uuid->toString();
+            $model->attributes[$model->uuidColumn()] = $model->hasCast($model->uuidColumn()) ? $uuid->getBytes() : $uuid->toString();
         });
     }
 

--- a/src/GeneratesUuid.php
+++ b/src/GeneratesUuid.php
@@ -61,7 +61,7 @@ trait GeneratesUuid
                 $uuid = $uuid->fromString(strtolower($model->attributes[$model->uuidColumn()]));
             }
 
-            $model->attributes[$model->uuidColumn()] = $model->hasCast($model->uuidColumn()) ? $uuid->getBytes() : $uuid->toString();
+            $model->attributes[$model->uuidColumn()] = $model->hasCast($model->uuidColumn(), 'uuid') ? $uuid->getBytes() : $uuid->toString();
         });
     }
 

--- a/tests/Feature/UuidTest.php
+++ b/tests/Feature/UuidTest.php
@@ -4,6 +4,7 @@ namespace Tests\Feature;
 
 use Tests\Fixtures\Post;
 use Tests\Fixtures\UncastPost;
+use Tests\Fixtures\CustomCastUuidPost;
 use PHPUnit\Framework\TestCase;
 use Tests\Fixtures\OrderedPost;
 use Illuminate\Events\Dispatcher;
@@ -68,6 +69,14 @@ class UuidTest extends TestCase
         $this->assertNotNull($post->uuid);
     }
 
+    /** @test */
+    public function you_can_generate_a_uuid_with_casting_and_a_custom_field_name()
+    {
+        $post = CustomCastUuidPost::create(['title' => 'test post']);
+
+        $this->assertNotNull($post->custom_uuid);
+    }
+    
     /** @test */
     public function you_can_specify_a_uuid_without_casting()
     {

--- a/tests/Feature/UuidTest.php
+++ b/tests/Feature/UuidTest.php
@@ -4,12 +4,12 @@ namespace Tests\Feature;
 
 use Tests\Fixtures\Post;
 use Tests\Fixtures\UncastPost;
-use Tests\Fixtures\CustomCastUuidPost;
 use PHPUnit\Framework\TestCase;
 use Tests\Fixtures\OrderedPost;
 use Illuminate\Events\Dispatcher;
 use Tests\Fixtures\CustomUuidPost;
 use Illuminate\Container\Container;
+use Tests\Fixtures\CustomCastUuidPost;
 use Illuminate\Database\Capsule\Manager;
 
 class UuidTest extends TestCase

--- a/tests/Fixtures/CustomCastUuidPost.php
+++ b/tests/Fixtures/CustomCastUuidPost.php
@@ -1,0 +1,17 @@
+<?php
+
+namespace Tests\Fixtures;
+
+class CustomCastUuidPost extends Model
+{
+
+    /**
+     * {@inheritdoc}
+     */
+    protected $casts = ['custom_uuid' => 'uuid'];
+    
+    public function uuidColumn()
+    {
+        return 'custom_uuid';
+    }
+}


### PR DESCRIPTION
Casting worked if the UUID field was called "uuid", but not if using a custom UUID field name.