### PR TITLE
Update scopeWhereUuid to reflect both types

### DIFF
--- a/src/GeneratesUuid.php
+++ b/src/GeneratesUuid.php
@@ -128,7 +128,7 @@ trait GeneratesUuid
      * Scope queries to find by UUID.
      *
      * @param  \Illuminate\Database\Eloquent\Builder  $query
-     * @param  string  $uuid
+     * @param  string|array  $uuid
      * @param  string  $uuidColumn
      *
      * @return \Illuminate\Database\Eloquent\Builder


### PR DESCRIPTION
I've been running some static analysis tools over a project I'm working on and they've highlighted an issue in the PHPDoc on the `scopeWhereUuid` method. The `$uuid` can be either a string or an array

I realise this is a pedantic one, I thought it might help other people running into the same warning

Thanks for this amazing library 😀