### PR TITLE
Proposal: Use the `casts` array to figure out which columns are UUIDs

### DIFF
--- a/src/GeneratesUuid.php
+++ b/src/GeneratesUuid.php
@@ -84,7 +84,9 @@ trait GeneratesUuid
      */
     public function uuidColumns(): array
     {
-        return [$this->uuidColumn()];
+        return  collect($this->casts)->filter(function ($value, $key) {
+            return 'Dyrynda\Database\Casts\EfficientUuid' === $value;
+        })->keys()->toArray();
     }
 
     /**


### PR DESCRIPTION
Hi, I really like this package, thanks for making it!  I was trying to solve an issue with a different package I was using and I ended up playing around with the idea of just dynamically figuring out which columns were using the UUID by just looping over the `$this->casts` array. I have this code in my own local models and it works fine. *This code* in particular isn't ready to be merged, but before I clean it up I wanted to see if you'd be interested in this approach or if there's something I'm not considering that would make this a bad approach!