### PR TITLE
Prepend column name with table name.

### DIFF
--- a/src/GeneratesUuid.php
+++ b/src/GeneratesUuid.php
@@ -134,6 +134,9 @@ trait GeneratesUuid
             $uuid = $this->bytesFromUuid($uuid);
         }
 
+        // Qualify the given column name by the model's table.
+        $uuidColumn = $this->qualifyColumn($uuidColumn);
+
         return $query->whereIn($uuidColumn, Arr::wrap($uuid));
     }
 


### PR DESCRIPTION
This PR makes is possible to use whereUuid on relations where both models have a uuid field.

ex: A `Project` model with a `Deployments` `hasManyThrough` relation (from: https://laravel.com/docs/8.x/eloquent-relationships#has-many-through)

query:
```php
$deployment = $project->deployments()
                  ->whereUuid($uuid)
                  ->dd();
```

before change:
```mysql
select * from `deployments` 
inner join `environments` on `environments`.`id` = `deployments`.`environment_id` 
where `environments`.`project_id` = ? 
and `uuid` in (?) #difference
and `deployments`.`deleted_at` is null 
and `environments`.`deleted_at` is null
```

after change:
```mysql
select * from `deployments` 
inner join `environments` on `environments`.`id` = `deployments`.`environment_id` 
where `environments`.`project_id` = ? 
and `deployments`.`uuid` in (?) #difference
and `deployments`.`deleted_at` is null 
and `environments`.`deleted_at` is null
```