### PR TITLE
Ability to bind on desired uuid column from model

### DIFF
--- a/README.md
+++ b/README.md
@@ -142,10 +142,27 @@ class Post extends Model
 
 ## Route model binding
 
-Should you wish to leverage implicit route model binding on your `uuid` field, you'll need to override the `getRouteKeyName` method in your Eloquent model.
+From 6.5.0, should you wish to leverage implicit route model binding on your `uuid` field, you may use the `BindsOnUuid` trait, which will use the configured `uuidColumn` by default.
 
 ```php
-public function getRouteKeyName()
+<?php
+
+namespace App;
+
+use Dyrynda\Database\Support\BindsOnUuid;
+use Dyrynda\Database\Support\GeneratesUuid;
+use Illuminate\Database\Eloquent\Model;
+
+class Post extends Model
+{
+    use BindsOnUuid, GeneratesUuid;
+}
+```
+
+Should you require additional control over the binding, or are using < 6.5.0 of this package, you may override the `getRouteKeyName` method directly.
+
+```php
+public function getRouteKeyName(): string
 {
     return 'uuid';
 }

--- a/src/BindsOnUuid.php
+++ b/src/BindsOnUuid.php
@@ -19,4 +19,14 @@ trait BindsOnUuid
 	{
 		return self::whereUuid($value, $field)->firstOrFail();
 	}
+
+	/**
+	 * Get the route key for the model.
+	 *
+	 * @return string
+	 */
+	public function getRouteKeyName(): string
+	{
+		return $this->uuidColumn();
+	}
 }

--- a/src/BindsOnUuid.php
+++ b/src/BindsOnUuid.php
@@ -1,0 +1,22 @@
+<?php
+
+namespace Dyrynda\Database\Support;
+
+use Illuminate\Database\Eloquent\Model;
+
+trait BindsOnUuid
+{
+	/**
+	 * Route bind desired uuid field
+	 * Default 'uuid' column name has been set
+	 *
+	 * @param string $value
+	 * @param null|string $field
+	 *
+	 * @return \Illuminate\Database\Eloquent\Model
+	 */
+	public function resolveRouteBinding($value, $field = null): Model
+	{
+		return self::whereUuid($value, $field)->firstOrFail();
+	}
+}

--- a/tests/Feature/BindUuidTest.php
+++ b/tests/Feature/BindUuidTest.php
@@ -1,0 +1,84 @@
+<?php
+
+namespace Tests\Feature;
+
+use Tests\TestCase;
+use Illuminate\Support\Facades\Route;
+use Tests\Fixtures\UuidRouteBoundPost;
+use Tests\Fixtures\CustomUuidRouteBoundPost;
+use Tests\Fixtures\MultipleUuidRouteBoundPost;
+
+class BindUuidTest extends TestCase
+{
+	/** @test */
+	public function it_binds_to_default_uuid_field()
+	{
+		$post = factory(UuidRouteBoundPost::class)->create();
+
+		Route::middleware('bindings')->get('/posts/{post}', function (UuidRouteBoundPost $post) {
+			return $post;
+		});
+
+		$this->get('/posts/' . $post->uuid)->assertSuccessful();
+	}
+
+	/** @test */
+	public function it_fails_on_invalid_default_uuid_field_value()
+	{
+		$post = factory(UuidRouteBoundPost::class)->create();
+
+		Route::middleware('bindings')->get('/posts/{post}', function (UuidRouteBoundPost $post) {
+			return $post;
+		});
+
+		$this->get('/posts/' . $post->custom_uuid)->assertNotFound();
+	}
+
+	/** @test */
+	public function it_binds_to_custom_uuid_field()
+	{
+		$post = factory(CustomUuidRouteBoundPost::class)->create();
+
+		Route::middleware('bindings')->get('/posts/{post}', function (CustomUuidRouteBoundPost $post) {
+			return $post;
+		});
+
+		$this->get('/posts/' . $post->custom_uuid)->assertSuccessful();
+	}
+
+	/** @test */
+	public function it_fails_on_invalid_custom_uuid_field_value()
+	{
+		$post = factory(CustomUuidRouteBoundPost::class)->create();
+
+		Route::middleware('bindings')->get('/posts/{post}', function (CustomUuidRouteBoundPost $post) {
+			return $post;
+		});
+
+		$this->get('/posts/' . $post->uuid)->assertNotFound();
+	}
+
+	/** @test */
+	public function it_binds_to_declared_uuid_column_instead_of_default_when_custom_key_used()
+	{
+		$post = factory(MultipleUuidRouteBoundPost::class)->create();
+
+		Route::middleware('bindings')->get('/posts/{post:custom_uuid}', function (MultipleUuidRouteBoundPost $post) {
+			return $post;
+		});
+
+		$this->get('/posts/' . $post->custom_uuid)->assertSuccessful();
+	}
+
+	/** @test */
+	public function it_fails_on_invalid_uuid_when_custom_route_key_used()
+	{
+		$post = factory(MultipleUuidRouteBoundPost::class)->create();
+
+		Route::middleware('bindings')->get('/posts/{post:custom_uuid}', function (MultipleUuidRouteBoundPost $post) {
+			return $post;
+		});
+
+		$this->get('/posts/' . $post->custom_uuid)->assertSuccessful();
+	}
+}

--- a/tests/Feature/BindUuidTest.php
+++ b/tests/Feature/BindUuidTest.php
@@ -17,9 +17,10 @@ class BindUuidTest extends TestCase
 
 		Route::middleware('bindings')->get('/posts/{post}', function (UuidRouteBoundPost $post) {
 			return $post;
-		});
+		})->name('posts.show');
 
 		$this->get('/posts/' . $post->uuid)->assertSuccessful();
+		$this->get(route('posts.show', $post))->assertSuccessful();
 	}
 
 	/** @test */
@@ -29,9 +30,10 @@ class BindUuidTest extends TestCase
 
 		Route::middleware('bindings')->get('/posts/{post}', function (UuidRouteBoundPost $post) {
 			return $post;
-		});
+		})->name('posts.show');
 
 		$this->get('/posts/' . $post->custom_uuid)->assertNotFound();
+		$this->get(route('posts.show', $post->custom_uuid))->assertNotFound();
 	}
 
 	/** @test */
@@ -41,9 +43,10 @@ class BindUuidTest extends TestCase
 
 		Route::middleware('bindings')->get('/posts/{post}', function (CustomUuidRouteBoundPost $post) {
 			return $post;
-		});
+		})->name('posts.show');
 
 		$this->get('/posts/' . $post->custom_uuid)->assertSuccessful();
+		$this->get(route('posts.show', $post))->assertSuccessful();
 	}
 
 	/** @test */
@@ -53,9 +56,10 @@ class BindUuidTest extends TestCase
 
 		Route::middleware('bindings')->get('/posts/{post}', function (CustomUuidRouteBoundPost $post) {
 			return $post;
-		});
+		})->name('posts.show');
 
 		$this->get('/posts/' . $post->uuid)->assertNotFound();
+		$this->get(route('posts.show', $post->uuid))->assertNotFound();
 	}
 
 	/** @test */
@@ -65,9 +69,10 @@ class BindUuidTest extends TestCase
 
 		Route::middleware('bindings')->get('/posts/{post:custom_uuid}', function (MultipleUuidRouteBoundPost $post) {
 			return $post;
-		});
+		})->name('posts.show');
 
 		$this->get('/posts/' . $post->custom_uuid)->assertSuccessful();
+		$this->get(route('posts.show', $post))->assertSuccessful();
 	}
 
 	/** @test */

--- a/tests/Feature/BindUuidTest.php
+++ b/tests/Feature/BindUuidTest.php
@@ -82,8 +82,9 @@ class BindUuidTest extends TestCase
 
 		Route::middleware('bindings')->get('/posts/{post:custom_uuid}', function (MultipleUuidRouteBoundPost $post) {
 			return $post;
-		});
+		})->name('posts.show');
 
-		$this->get('/posts/' . $post->custom_uuid)->assertSuccessful();
+		$this->get('/posts/' . $post->uuid)->assertNotFound();
+		$this->get(route('posts.show', $post->uuid))->assertNotFound();
 	}
 }

--- a/tests/Fixtures/CustomUuidRouteBoundPost.php
+++ b/tests/Fixtures/CustomUuidRouteBoundPost.php
@@ -1,0 +1,15 @@
+<?php
+
+namespace Tests\Fixtures;
+
+use Dyrynda\Database\Support\BindsOnUuid;
+
+class CustomUuidRouteBoundPost extends Model
+{
+	use BindsOnUuid;
+
+	public function uuidColumn(): string
+	{
+		return 'custom_uuid';
+	}
+}

--- a/tests/Fixtures/MultipleUuidRouteBoundPost.php
+++ b/tests/Fixtures/MultipleUuidRouteBoundPost.php
@@ -1,0 +1,17 @@
+<?php
+
+namespace Tests\Fixtures;
+
+use Dyrynda\Database\Support\BindsOnUuid;
+
+class MultipleUuidRouteBoundPost extends Model
+{
+	use BindsOnUuid;
+
+	public function uuidColumns(): array
+	{
+		return [
+			'uuid', 'custom_uuid'
+		];
+	}
+}

--- a/tests/Fixtures/UuidRouteBoundPost.php
+++ b/tests/Fixtures/UuidRouteBoundPost.php
@@ -1,0 +1,15 @@
+<?php
+
+namespace Tests\Fixtures;
+
+use Dyrynda\Database\Support\BindsOnUuid;
+
+class UuidRouteBoundPost extends Model
+{
+	use BindsOnUuid;
+
+	public function uuidColumn(): string
+	{
+		return 'uuid';
+	}
+}

--- a/tests/database/factories/PostFactory.php
+++ b/tests/database/factories/PostFactory.php
@@ -9,6 +9,9 @@ use Tests\Fixtures\EfficientUuidPost;
 use Tests\Fixtures\MultipleUuidPost;
 use Tests\Fixtures\OrderedPost;
 use Tests\Fixtures\Post;
+use Tests\Fixtures\UuidRouteBoundPost;
+use Tests\Fixtures\CustomUuidRouteBoundPost;
+use Tests\Fixtures\MultipleUuidRouteBoundPost;
 
 $factory->define(CustomCastUuidPost::class, function (Faker $faker) {
     return [
@@ -58,4 +61,28 @@ $factory->define(UncastPostPost::class, function (Faker $faker) {
         'uuid' => $faker->uuid,
         'title' => $faker->sentence,
     ];
+});
+
+$factory->define(CustomUuidRouteBoundPost::class, function (Faker $faker) {
+	return [
+		'uuid' => $faker->uuid,
+		'custom_uuid' => $faker->uuid,
+		'title' => $faker->sentence,
+	];
+});
+
+$factory->define(UuidRouteBoundPost::class, function (Faker $faker) {
+	return [
+		'uuid' => $faker->uuid,
+		'custom_uuid' => $faker->uuid,
+		'title' => $faker->sentence,
+	];
+});
+
+$factory->define(MultipleUuidRouteBoundPost::class, function (Faker $faker) {
+	return [
+		'uuid' => $faker->uuid,
+		'custom_uuid' => $faker->uuid,
+		'title' => $faker->sentence,
+	];
 });


### PR DESCRIPTION
When used on model, the added trait adds the ability to route bind the model to desired uuid column,
As an example:

```
Route::get('users/{user}', function (User $user){
	return $user;
});
```

Above code would bind on default 'uuid' column name and perform under "whereUuid" scope.

Also in case model has more than one uuid column and/or any name other than 'uuid' is set for column, the added trait feeds the custom column name to responsible scope:

```
public function uuidColumns(): array
{
	return ['uuid', 'other_uuid_column'];
}

Route::get('users/{user:other_uuid_column}', function (User $user){
	return $user;
});
```
As usual custom columns should be registered within "uuidColumns" function.