### PR TITLE
Validation for UUIDs passed to the `whereUuid` scope

### DIFF
--- a/src/GeneratesUuid.php
+++ b/src/GeneratesUuid.php
@@ -126,9 +126,7 @@ trait GeneratesUuid
             ? $uuidColumn
             : $this->uuidColumns()[0];
 
-        $uuid = array_map(function ($uuid) {
-            return Str::lower($uuid);
-        }, Arr::wrap($uuid));
+        $uuid = $this->normaliseUuids($uuid);
 
         if ($this->isClassCastable($uuidColumn)) {
             $uuid = $this->bytesFromUuid($uuid);
@@ -157,5 +155,20 @@ trait GeneratesUuid
         }
 
         return Arr::wrap(Uuid::fromString($uuid)->getBytes());
+    }
+
+    /**
+     * Normalises a single or array of input UUIDs, filtering any invalid UUIDs.
+     *
+     * @param  \Illuminate\Contracts\Support\Arrayable|array|string  $uuid
+     * @return array
+     */
+    protected function normaliseUuids($uuid) : array
+    {
+        $uuid = array_map(fn ($uuid) => Str::lower($uuid), Arr::wrap($uuid));
+
+        $uuid = array_filter($uuid, fn ($uuid) => Uuid::isValid($uuid));
+
+        return $uuid;
     }
 }

--- a/src/GeneratesUuid.php
+++ b/src/GeneratesUuid.php
@@ -163,7 +163,7 @@ trait GeneratesUuid
      * @param  \Illuminate\Contracts\Support\Arrayable|array|string  $uuid
      * @return array
      */
-    protected function normaliseUuids($uuid) : array
+    protected function normaliseUuids($uuid): array
     {
         $uuid = array_map(fn ($uuid) => Str::lower($uuid), Arr::wrap($uuid));
 

--- a/tests/Feature/UuidTest.php
+++ b/tests/Feature/UuidTest.php
@@ -3,6 +3,7 @@
 namespace Tests\Feature;
 
 use Illuminate\Database\Eloquent\Model;
+use Illuminate\Database\Eloquent\ModelNotFoundException;
 use Illuminate\Foundation\Testing\WithFaker;
 use Ramsey\Uuid\Uuid;
 use Tests\Fixtures\Comment;
@@ -225,8 +226,9 @@ class UuidTest extends TestCase
 
         EfficientUuidPost::create(['title' => 'efficient uuid', 'efficient_uuid' => $uuid]);
 
-        $post = EfficientUuidPost::whereUuid('invalid uuid')->first();
-        $this->assertNull($post);
+        $this->expectException(ModelNotFoundException::class);
+
+        EfficientUuidPost::whereUuid('invalid uuid')->firstOrFail();
     }
 
     /** @test */

--- a/tests/Feature/UuidTest.php
+++ b/tests/Feature/UuidTest.php
@@ -206,6 +206,21 @@ class UuidTest extends TestCase
     }
 
     /** @test */
+    public function it_handles_an_invalid_uuid()
+    {
+        $uuid = 'b270f651-4db8-407b-aade-8666aca2750e';
+
+        EfficientUuidPost::create(['title' => 'efficient uuid', 'efficient_uuid' => $uuid]);
+
+        $post = EfficientUuidPost::whereUuid('invalid uuid')->first();
+        $this->assertNull($post);
+
+        $post = EfficientUuidPost::whereUuid(['invalid uuid', 'b270f651-4db8-407b-aade-8666aca2750e'])->first();
+        $this->assertInstanceOf(EfficientUuidPost::class, $post);
+        $this->assertSame($uuid, $post->efficient_uuid);
+    }
+
+    /** @test */
     public function it_handles_a_null_uuid_column()
     {
         tap(Model::withoutEvents(function () {

--- a/tests/Feature/UuidTest.php
+++ b/tests/Feature/UuidTest.php
@@ -111,6 +111,19 @@ class UuidTest extends TestCase
     }
 
     /** @test */
+    public function you_can_search_by_array_of_uuids_which_contains_an_invalid_uuid()
+    {
+        $first = EfficientUuidPost::create(['title' => 'first post', 'uuid' => '8ab48e77-d9cd-4fe7-ace5-a5a428590c18']);
+        $second = EfficientUuidPost::create(['title' => 'second post', 'uuid' => 'c7c26456-ddb0-45cd-9b1c-318296cce7a3']);
+
+        $this->assertEquals(2, Post::whereUuid([
+            '8ab48e77-d9cd-4fe7-ace5-A5A428590C18',
+            'c7c26456-ddb0-45cd-9b1c-318296cce7a3',
+            'this is invalid'
+        ])->count());
+    }
+
+    /** @test */
     public function you_can_generate_a_uuid_without_casting()
     {
         $post = UncastPost::create(['title' => 'test post']);
@@ -214,10 +227,6 @@ class UuidTest extends TestCase
 
         $post = EfficientUuidPost::whereUuid('invalid uuid')->first();
         $this->assertNull($post);
-
-        $post = EfficientUuidPost::whereUuid(['invalid uuid', 'b270f651-4db8-407b-aade-8666aca2750e'])->first();
-        $this->assertInstanceOf(EfficientUuidPost::class, $post);
-        $this->assertSame($uuid, $post->efficient_uuid);
     }
 
     /** @test */

--- a/tests/Feature/UuidTest.php
+++ b/tests/Feature/UuidTest.php
@@ -119,7 +119,7 @@ class UuidTest extends TestCase
         $this->assertEquals(2, Post::whereUuid([
             '8ab48e77-d9cd-4fe7-ace5-A5A428590C18',
             'c7c26456-ddb0-45cd-9b1c-318296cce7a3',
-            'this is invalid'
+            'this is invalid',
         ])->count());
     }
 


### PR DESCRIPTION
This PR proposes a simple change to fix #114, and works for either a model using `EfficientUuid` or using PostgreSQL's native UUID data type.

Note: I didn't update the GitHub Actions workflow to also run the test suite against a PostgreSQL too, but I'm happy to append the PR with that change if you'd like that added.