### PR TITLE
add tests to cover scenarios when saving/updating an existing efficient UUID record

### DIFF
--- a/tests/Feature/UuidTest.php
+++ b/tests/Feature/UuidTest.php
@@ -10,9 +10,11 @@ use Tests\Fixtures\Comment;
 use Tests\Fixtures\CustomCastUuidPost;
 use Tests\Fixtures\CustomUuidPost;
 use Tests\Fixtures\EfficientUuidPost;
+use Tests\Fixtures\MultipleEfficientUuidPost;
 use Tests\Fixtures\MultipleUuidPost;
 use Tests\Fixtures\OrderedPost;
 use Tests\Fixtures\Post;
+use Tests\Fixtures\PrimaryEfficientUuidPost;
 use Tests\Fixtures\UncastPost;
 use Tests\Fixtures\Uuid1Post;
 use Tests\Fixtures\Uuid4Post;
@@ -282,6 +284,52 @@ class UuidTest extends TestCase
             $this->assertNotNull($comment);
             $this->assertEquals('4e6c964d-4e9b-4023-be0e-f5a6529b7184', $comment->post->uuid);
         });
+    }
+
+    /** @test */
+    public function it_handles_updating_an_efficient_uuid_model_with_multiple_casts()
+    {
+        $post = factory(MultipleEfficientUuidPost::class)->create();
+
+        $post->update([
+            'title' => 'The title is updated',
+        ]);
+
+        $this->assertEquals('The title is updated', $post->fresh()->title);
+    }
+
+    /** @test */
+    public function it_handles_saving_an_efficient_uuid_model_with_multiple_casts()
+    {
+        $post = factory(MultipleEfficientUuidPost::class)->create();
+
+        $post->title = 'The title updated';
+        $post->save();
+
+        $this->assertEquals('The title updated', $post->fresh()->title);
+    }
+
+    /** @test */
+    public function it_handles_updating_an_efficient_uuid_model_with_multiple_casts_and_a_primary_efficient_id()
+    {
+        $post = factory(PrimaryEfficientUuidPost::class)->create();
+
+        $post->update([
+            'title' => 'The title is updated',
+        ]);
+
+        $this->assertEquals('The title is updated', $post->fresh()->title);
+    }
+
+    /** @test */
+    public function it_handles_saving_an_efficient_uuid_model_with_multiple_casts_and_a_primary_efficient_id()
+    {
+        $post = factory(PrimaryEfficientUuidPost::class)->create();
+
+        $post->title = 'The title is updated';
+        $post->save();
+
+        $this->assertEquals('The title is updated', $post->fresh()->title);
     }
 
     public function factoriesWithUuidProvider(): array

--- a/tests/Fixtures/MultipleEfficientUuidPost.php
+++ b/tests/Fixtures/MultipleEfficientUuidPost.php
@@ -1,0 +1,24 @@
+<?php
+
+namespace Tests\Fixtures;
+
+use Dyrynda\Database\Casts\EfficientUuid;
+use Dyrynda\Database\Support\GeneratesUuid;
+
+class MultipleEfficientUuidPost extends Model
+{
+    use GeneratesUuid;
+
+    /**
+     * {@inheritdoc}
+     */
+    protected $casts = [
+        'efficient_uuid' => EfficientUuid::class,
+        'another_efficient_uuid' => EfficientUuid::class,
+    ];
+
+    public function uuidColumns(): array
+    {
+        return ['efficient_uuid', 'another_efficient_uuid'];
+    }
+}

--- a/tests/Fixtures/PrimaryEfficientUuidPost.php
+++ b/tests/Fixtures/PrimaryEfficientUuidPost.php
@@ -1,0 +1,28 @@
+<?php
+
+namespace Tests\Fixtures;
+
+use Dyrynda\Database\Casts\EfficientUuid;
+use Dyrynda\Database\Support\GeneratesUuid;
+
+class PrimaryEfficientUuidPost extends Model
+{
+    use GeneratesUuid;
+
+    /**
+     * {@inheritdoc}
+     */
+    protected $casts = [
+        'id' => EfficientUuid::class,
+        'efficient_uuid' => EfficientUuid::class,
+    ];
+
+    public $table = 'efficient_posts';
+
+    public $incrementing = false;
+
+    public function uuidColumns(): array
+    {
+        return ['id', 'efficient_uuid'];
+    }
+}

--- a/tests/TestCase.php
+++ b/tests/TestCase.php
@@ -34,6 +34,13 @@ class TestCase extends OrchestraTestCase
             $table->uuid('uuid')->nullable();
             $table->uuid('custom_uuid')->nullable();
             $table->efficientUuid('efficient_uuid')->nullable();
+            $table->efficientUuid('another_efficient_uuid')->nullable();
+            $table->string('title');
+        });
+
+        $app['db']->connection()->getSchemaBuilder()->create('efficient_posts', function (Blueprint $table) {
+            $table->efficientUuid('id')->primary();
+            $table->efficientUuid('efficient_uuid')->nullable();
             $table->string('title');
         });
 

--- a/tests/database/factories/PostFactory.php
+++ b/tests/database/factories/PostFactory.php
@@ -7,10 +7,12 @@ use Tests\Fixtures\CustomCastUuidPost;
 use Tests\Fixtures\CustomUuidPost;
 use Tests\Fixtures\CustomUuidRouteBoundPost;
 use Tests\Fixtures\EfficientUuidPost;
+use Tests\Fixtures\MultipleEfficientUuidPost;
 use Tests\Fixtures\MultipleUuidPost;
 use Tests\Fixtures\MultipleUuidRouteBoundPost;
 use Tests\Fixtures\OrderedPost;
 use Tests\Fixtures\Post;
+use Tests\Fixtures\PrimaryEfficientUuidPost;
 use Tests\Fixtures\UuidRouteBoundPost;
 
 $factory->define(CustomCastUuidPost::class, function (Faker $faker) {
@@ -29,6 +31,22 @@ $factory->define(CustomUuidPost::class, function (Faker $faker) {
 
 $factory->define(EfficientUuidPost::class, function (Faker $faker) {
     return [
+        'efficient_uuid' => $faker->uuid,
+        'title' => $faker->sentence,
+    ];
+});
+
+$factory->define(MultipleEfficientUuidPost::class, function (Faker $faker) {
+    return [
+        'efficient_uuid' => $faker->uuid,
+        'another_efficient_uuid' => $faker->uuid,
+        'title' => $faker->sentence,
+    ];
+});
+
+$factory->define(PrimaryEfficientUuidPost::class, function (Faker $faker) {
+    return [
+        'id' => $faker->uuid,
         'efficient_uuid' => $faker->uuid,
         'title' => $faker->sentence,
     ];


### PR DESCRIPTION
Adds tests to cover the failing scenario described in michaeldyrynda/laravel-efficient-uuid#55

I've not been able to reproduce the bug, either with supplemental efficient UUID values, or with the primary id as an efficient UUID.

Hoping to work with @schmoove to first create some failing test cases, then solve the issue.
