### PR TITLE
Add configuration option to set default UUID table name. Closes #125.

### DIFF
--- a/README.md
+++ b/README.md
@@ -67,7 +67,7 @@ class Post extends Model
 }
 ```
 
-A default column name can also be configured. Simply create a config file called `config/model-uuid.php` and edit its contents. For example, to change the default UUID column name to `uuid_binary`, modify `config/model-uuid.php` like so:
+A default column name can also be configured. Simply create a config file called `config/model-uuid.php` and edit its contents. For example, to change the default UUID column name to `uuid_binary`, modify your `config/model-uuid.php` like so:
 
 ```php
 <?php
@@ -77,7 +77,7 @@ return [
      * The default column name which should be used to store the generated UUID value.
      * Note: This can still be overwritten by declaring a `uuidColumn()` method in your model(s).
      */
-    'default_column_name' => 'uuid',
+    'default_column_name' => 'uuid_binary',
 ];
 
 ```

--- a/README.md
+++ b/README.md
@@ -67,6 +67,21 @@ class Post extends Model
 }
 ```
 
+A default column name can also be configured. Simply create a config file called `config/model-uuid.php` and edit its contents. For example, to change the default UUID column name to `uuid_binary`, modify `config/model-uuid.php` like so:
+
+```php
+<?php
+
+return [
+    /**
+     * The default column name which should be used to store the generated UUID value.
+     * Note: This can still be overwritten by declaring a `uuidColumn()` method in your model(s).
+     */
+    'default_column_name' => 'uuid',
+];
+
+```
+
 By default, this package will use UUID version 4 values, however, you are welcome to use `uuid1`, `uuid4`, or `uuid6` by specifying the protected property `$uuidVersion` in your model. Should you wish to take advantage of [ordered UUID (version 4) values that were introduced in Laravel 5.6](https://laravel.com/docs/master/helpers#method-str-ordered-uuid), you should specify `ordered` as the `$uuidVersion` in your model.
 
 ```php

--- a/config/model-uuid.php
+++ b/config/model-uuid.php
@@ -1,0 +1,9 @@
+<?php
+
+return [
+    /**
+     * The default column name which should be used to store the generated UUID value.
+     * Note: This can still be overwritten by declaring a `uuidColumn()` method in your model(s).
+     */
+    'default_column_name' => 'uuid',
+];

--- a/src/GeneratesUuid.php
+++ b/src/GeneratesUuid.php
@@ -75,7 +75,7 @@ trait GeneratesUuid
      */
     public function uuidColumn(): string
     {
-        return 'uuid';
+        return config('model-uuid.default_column_name', 'uuid');
     }
 
     /**

--- a/src/GeneratesUuid.php
+++ b/src/GeneratesUuid.php
@@ -23,7 +23,7 @@ use Ramsey\Uuid\UuidInterface;
  *
  * @property string $uuidVersion
  *
- * @method static \Illuminate\Database\Eloquent\Builder  whereUuid(string $uuid)
+ * @method static \Illuminate\Database\Eloquent\Builder whereUuid(string $uuid)
  */
 trait GeneratesUuid
 {

--- a/src/LaravelModelUuidServiceProvider.php
+++ b/src/LaravelModelUuidServiceProvider.php
@@ -14,7 +14,7 @@ class LaravelModelUuidServiceProvider extends ServiceProvider
     public function register()
     {
         // Load package configuration file
-        $configPath = __DIR__ . '/../config/model-uuid.php';
+        $configPath = __DIR__.'/../config/model-uuid.php';
         $this->mergeConfigFrom($configPath, 'model-uuid');
 
         // Add ability to publish the configuration file

--- a/src/LaravelModelUuidServiceProvider.php
+++ b/src/LaravelModelUuidServiceProvider.php
@@ -1,0 +1,23 @@
+<?php
+
+namespace Dyrynda\Database\Support;
+
+use Illuminate\Support\ServiceProvider;
+
+class LaravelModelUuidServiceProvider extends ServiceProvider
+{
+    /**
+     * Register the service provider.
+     *
+     * @return void
+     */
+    public function register()
+    {
+        // Load package configuration file
+        $configPath = __DIR__ . '/../config/model-uuid.php';
+        $this->mergeConfigFrom($configPath, 'model-uuid');
+
+        // Add ability to publish the configuration file
+        $this->publishes([$configPath => config_path('model-uuid.php')], 'config');
+    }
+}

--- a/tests/Feature/GeneratesUuidTest.php
+++ b/tests/Feature/GeneratesUuidTest.php
@@ -1,0 +1,33 @@
+<?php
+
+namespace Tests\Feature;
+
+use Dyrynda\Database\Support\GeneratesUuid;
+use Config;
+use Tests\TestCase;
+
+class GeneratesUuidTest extends TestCase
+{
+    /**
+     * @test
+     */
+    public function it_gets_default_column_name()
+    {
+        $testModelThatGeneratesUuid = new class() {
+            use GeneratesUuid;
+        };
+
+        $this->assertSame(
+            $testModelThatGeneratesUuid->uuidColumn(),
+            'uuid',
+            'The UUID column should be "uuid" when no default is configured.'
+        );
+
+        Config::set('model-uuid.default_column_name', 'uuid_custom');
+        $this->assertSame(
+            $testModelThatGeneratesUuid->uuidColumn(),
+            'uuid_custom',
+            'The UUID column should match the configured value.'
+        );
+    }
+}

--- a/tests/Feature/GeneratesUuidTest.php
+++ b/tests/Feature/GeneratesUuidTest.php
@@ -2,8 +2,8 @@
 
 namespace Tests\Feature;
 
-use Dyrynda\Database\Support\GeneratesUuid;
 use Config;
+use Dyrynda\Database\Support\GeneratesUuid;
 use Tests\TestCase;
 
 class GeneratesUuidTest extends TestCase
@@ -13,7 +13,8 @@ class GeneratesUuidTest extends TestCase
      */
     public function it_gets_default_column_name()
     {
-        $testModelThatGeneratesUuid = new class() {
+        $testModelThatGeneratesUuid = new class()
+        {
             use GeneratesUuid;
         };
 


### PR DESCRIPTION
Title says it all. Just create `config/model-uuid.php` and set `default_column_name` to whatever you want.

---

Note: The included ServiceProvider isn't used, but might be useful one day if additional items are added to `config/model-uuid.php`. It could also be auto loaded via `composer.json`. Instead of expecting the user to register the provider and publish the config, I simply updated the README with instructions on what to copy/paste.

With that said, I have no qualms removing the provider and package's config file from this PR.

Thanks for the great package, @michaeldyrynda!!