### PR TITLE
Update branch-alias as 8.x

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -48,7 +48,7 @@
     },
     "extra": {
         "branch-alias": {
-            "dev-main": "7.x-dev"
+            "dev-main": "8.x-dev"
         },
         "laravel": {
             "providers": [


### PR DESCRIPTION
Given that the latest update on `master` has been tagged with `8.0.0-beta.1`, it would seem that the intention is that `master` should now be aliased as `8.x-dev` instead of `7.x-dev`