### PR TITLE
Feature: Configurable UUID version

### DIFF
--- a/README.md
+++ b/README.md
@@ -85,14 +85,15 @@ class Post extends Model
 {
     use GeneratesUuid;
 
-    public function uuidVersion(): string
+    public function uuidVersion(): ?string
     {
         return 'uuid5';
     }
 }
 ```
 
-Alternatively, if you would like to use a different `$uuidVersion` on all of your models, then you can set the configuration setting to one of the versions outlined above.   If a different `$uuidVersion` is specified on a model then this will override the global setting.  Remove the ```public function uuidVersion(): string``` function from your model if it is set to take the global default.
+Alternatively, if you would like to use a consistent `$uuidVersion` on all of your models, you may set the `uuid_version` in your `config/model-uuid.php`.
+A non-empty value returned from the model's `uuidVersion(): ?string` method will take priority over the config version.
 
 ```php
 return [

--- a/README.md
+++ b/README.md
@@ -92,6 +92,17 @@ class Post extends Model
 }
 ```
 
+Alternatively, if you would like to use a different `$uuidVersion` on all of your models, then you can set the configuration setting to one of the versions outlined above.   If a different `$uuidVersion` is specified on a model then this will override the global setting.  Remove the ```public function uuidVersion(): string``` function from your model if it is set to take the global default.
+
+```php
+return [
+    /**
+     * The default uuid version used to generate UUID value.
+     */
+    'uuid_version' => 'uuid4',
+];
+```
+
 Whilst not recommended, if you _do_ choose to use a UUID as your primary model key (`id`), be sure to configure your model for this setup correctly. Not updating these properties will lead to Laravel attempting to convert your `id` column to an integer, which will be cast to `0`. When used in combination with the `EfficientUuid` cast, this casting will result in a `Ramsey\Uuid\Exception\InvalidUuidStringException` being thrown.
 
 ```php

--- a/config/model-uuid.php
+++ b/config/model-uuid.php
@@ -5,4 +5,9 @@ return [
      * The default column name which should be used to store the generated UUID value.
      */
     'column_name' => 'uuid',
+
+    /**
+     * The default uuid version used to generate UUID value.
+     */
+    'uuid_version' => 'uuid4',
 ];

--- a/src/GeneratesUuid.php
+++ b/src/GeneratesUuid.php
@@ -92,9 +92,9 @@ trait GeneratesUuid
         return call_user_func([Uuid::class, $this->resolveUuidVersion()]);
     }
 
-    public function uuidVersion(): string
+    public function uuidVersion(): string | null
     {
-        return 'uuid4';
+        return null;
     }
 
     /**
@@ -102,7 +102,10 @@ trait GeneratesUuid
      */
     public function resolveUuidVersion(): string
     {
-        if (($uuidVersion = $this->uuidVersion()) === 'ordered') {
+
+        $uuidVersion = $this->uuidVersion() ?? config('model-uuid.uuid_version', 'uuid4');
+
+        if ($uuidVersion === 'ordered') {
             $uuidVersion = 'uuid6';
         }
 

--- a/src/GeneratesUuid.php
+++ b/src/GeneratesUuid.php
@@ -92,7 +92,7 @@ trait GeneratesUuid
         return call_user_func([Uuid::class, $this->resolveUuidVersion()]);
     }
 
-    public function uuidVersion(): string | null
+    public function uuidVersion(): ?string
     {
         return null;
     }

--- a/tests/Feature/GeneratesUuidTest.php
+++ b/tests/Feature/GeneratesUuidTest.php
@@ -30,4 +30,61 @@ class GeneratesUuidTest extends TestCase
             'The UUID column should match the configured value.'
         );
     }
+
+    #[Test]
+    public function it_inherits_uuid_version_from_config()
+    {
+        Config::set('model-uuid.uuid_version', 'uuid1');
+
+        $testClass = new class
+        {
+            use GeneratesUuid;
+        };
+
+        $this->assertSame('uuid1', $testClass->resolveUuidVersion());
+    }
+
+    #[Test]
+    public function it_defaults_to_uuid4_when_config_not_set()
+    {
+        Config::set('model-uuid.uuid_version', null);
+
+        $testClass = new class
+        {
+            use GeneratesUuid;
+        };
+
+        $this->assertSame('uuid4', $testClass->resolveUuidVersion());
+    }
+
+    #[Test]
+    public function it_defaults_to_uuid4_when_config_is_empty()
+    {
+        Config::set('model-uuid.uuid_version', '');
+
+        $testClass = new class
+        {
+            use GeneratesUuid;
+        };
+
+        $this->assertSame('uuid4', $testClass->resolveUuidVersion());
+    }
+
+    #[Test]
+    public function it_uses_model_definition_as_highest_precedence()
+    {
+        Config::set('model-uuid.uuid_version', 'uuid7');
+
+        $testClass = new class
+        {
+            use GeneratesUuid;
+
+            public function uuidVersion(): ?string
+            {
+                return 'uuid6';
+            }
+        };
+
+        $this->assertSame('uuid6', $testClass->resolveUuidVersion());
+    }
 }


### PR DESCRIPTION
- Added additional configuration option for global uuid version
- Default is still uuid4 and if a different version is set on a model then that will take prescedence